### PR TITLE
improve connections handling

### DIFF
--- a/Sources/Netbob/Core/HTTPConnectionRepository.swift
+++ b/Sources/Netbob/Core/HTTPConnectionRepository.swift
@@ -7,63 +7,54 @@ import Foundation
 
 protocol HTTPConnectionRepositoryProtocol: AnyObject {
     var current: [HTTPConnection] { get }
-    var connections: AnyPublisher<[HTTPConnection], Never> { get }
-    var filteredConnections: AnyPublisher<[HTTPConnection], Never> { get }
+    var latestConnection: AnyPublisher<HTTPConnection, Never> { get }
     var allowedContentTypes: CurrentValueSubject<[HTTPContentType], Never> { get }
     func store(_ connection: HTTPConnection)
     func clear()
 }
 
 final class HTTPConnectionRepository: HTTPConnectionRepositoryProtocol {
+    private var connections: [HTTPConnection]?
+
     static let shared = HTTPConnectionRepository()
 
     let allowedContentTypes = CurrentValueSubject<[HTTPContentType], Never>(HTTPContentType.allCases)
 
-    var current: [HTTPConnection] { connectionsSubject.value }
-
-    private let connectionsSubject: CurrentValueSubject<[HTTPConnection], Never>
-    lazy var connections: AnyPublisher<[HTTPConnection], Never> = connectionsSubject.eraseToAnyPublisher()
-
-    lazy var filteredConnections: AnyPublisher<[HTTPConnection], Never> = Publishers
-        .CombineLatest(connections, allowedContentTypes)
-        .map { connections, allowedContentTypes in
-            connections.filter {
-                guard let contentType = $0.response?.contentType else { return false }
-                return allowedContentTypes.contains(contentType)
-            }
+    var current: [HTTPConnection] {
+        if connections == nil {
+            connections = try? diskStorage.read()
+            connections?.sort(by: { $0.request.date > $1.request.date })
         }
-        .eraseToAnyPublisher()
+        return connections ?? []
+    }
+
+    private let connectionSubject = PassthroughSubject<HTTPConnection, Never>()
+    var latestConnection: AnyPublisher<HTTPConnection, Never> {
+        connectionSubject.eraseToAnyPublisher()
+    }
 
     private let diskStorage: HTTPConnectionDiskStorageProtocol
 
     init(diskStorage: HTTPConnectionDiskStorageProtocol = HTTPConnectionDiskStorage()) {
-        let storedConnections: [HTTPConnection]
-        do {
-            storedConnections = try diskStorage.read()
-        } catch {
-            Netbob.log(String(describing: error))
-            storedConnections = []
-        }
-
         self.diskStorage = diskStorage
-        connectionsSubject = CurrentValueSubject<[HTTPConnection], Never>(storedConnections)
     }
 
     func store(_ connection: HTTPConnection) {
-        connectionsSubject.value.insert(connection, at: 0)
         do {
             try diskStorage.store(connection)
         } catch {
             Netbob.log(String(describing: error))
         }
+        connections?.insert(connection, at: 0)
+        connectionSubject.send(connection)
     }
 
     func clear() {
-        connectionsSubject.send([])
         do {
             try diskStorage.clear()
         } catch {
             Netbob.log(String(describing: error))
         }
+        connections?.removeAll()
     }
 }

--- a/Sources/Netbob/Core/Netbob.swift
+++ b/Sources/Netbob/Core/Netbob.swift
@@ -9,6 +9,7 @@ public final class Netbob {
     public static let version = "0.1.0"
 
     public var blacklistedHosts: [String] = []
+    public var maxListItems: Int?
 
     var allowedContentTypes: [HTTPContentType] {
         get { HTTPConnectionRepository.shared.allowedContentTypes.value }

--- a/Sources/Netbob/Modules/Info/InfoView.swift
+++ b/Sources/Netbob/Modules/Info/InfoView.swift
@@ -31,6 +31,12 @@ struct InfoView: View {
                 KeyValueView(key: "Slowest response time", value: state.summaryViewData.slowestResponseTime)
             }
         }
+        .onAppear {
+            state.onAppear()
+        }
+        .onDisappear {
+            state.onDisappear()
+        }
     }
 }
 

--- a/Sources/Netbob/Modules/List/ListView.swift
+++ b/Sources/Netbob/Modules/List/ListView.swift
@@ -17,6 +17,12 @@ struct ListView: View {
         }
         .navigationBarItems(trailing: navigationBarButtons)
         .activitySheet(state: $state.activitySheetState)
+        .onAppear {
+            state.onAppear()
+        }
+        .onDisappear {
+            state.onDisappear()
+        }
     }
 
     var navigationBarButtons: some View {

--- a/Sources/Netbob/Modules/Settings/SettingsView.swift
+++ b/Sources/Netbob/Modules/Settings/SettingsView.swift
@@ -7,6 +7,8 @@ import SwiftUI
 struct SettingsView: View {
     @StateObject var state: SettingsViewStateAbstract
 
+    private let maxItemsText = "MaxItems: "
+
     var body: some View {
         VStack {
             Form {
@@ -33,6 +35,25 @@ struct SettingsView: View {
                     }
                     .foregroundColor(.red)
                 }
+
+                Section {
+                    VStack {
+
+                        state.maxItems != nil ? Text("List limit: \(state.maxItems ?? 0)") : Text("List limit: no limit")
+
+                        Slider(
+                            value: maxItemsBinding,
+                            in: 100...1100,
+                            step: 100,
+                            label: { Text("Max list items") },
+                            minimumValueLabel: { Text("\(100)") },
+                            maximumValueLabel: { Text("no limit") },
+                            onEditingChanged: { value in
+                                Netbob.shared.maxListItems = state.maxItems
+                            }
+                        )
+                    }
+                }
             }
 
             Text(Netbob.version)
@@ -40,6 +61,14 @@ struct SettingsView: View {
         .navigationTitle("Settings")
         .actionSheet(item: $state.actionSheetState) { state in
             ActionSheet(state: state)
+        }
+    }
+
+    var maxItemsBinding: Binding<Double> {
+        .init {
+            Double(state.maxItems ?? 1100)
+        } set: { newValue in
+            state.maxItems = newValue == 1100 ? nil : Int(newValue)
         }
     }
 }

--- a/Sources/Netbob/Modules/Settings/SettingsView.swift
+++ b/Sources/Netbob/Modules/Settings/SettingsView.swift
@@ -38,17 +38,16 @@ struct SettingsView: View {
 
                 Section {
                     VStack {
-
                         state.maxItems != nil ? Text("List limit: \(state.maxItems ?? 0)") : Text("List limit: no limit")
 
                         Slider(
                             value: maxItemsBinding,
-                            in: 100...1100,
+                            in: 100 ... 1100,
                             step: 100,
                             label: { Text("Max list items") },
                             minimumValueLabel: { Text("\(100)") },
                             maximumValueLabel: { Text("no limit") },
-                            onEditingChanged: { value in
+                            onEditingChanged: { _ in
                                 Netbob.shared.maxListItems = state.maxItems
                             }
                         )

--- a/Sources/Netbob/Modules/Settings/SettingsViewState.swift
+++ b/Sources/Netbob/Modules/Settings/SettingsViewState.swift
@@ -9,6 +9,7 @@ class SettingsViewStateAbstract: ObservableObject {
     @Published var contentTypes: [ContentTypeSetting] = []
     @Published var actionSheetState: ActionSheetState?
     @Published var blacklistedHosts: [String] = []
+    @Published var maxItems: Int?  = Netbob.shared.maxListItems
 
     func handleClearAction() {}
 }

--- a/Sources/Netbob/Modules/Settings/SettingsViewState.swift
+++ b/Sources/Netbob/Modules/Settings/SettingsViewState.swift
@@ -9,7 +9,7 @@ class SettingsViewStateAbstract: ObservableObject {
     @Published var contentTypes: [ContentTypeSetting] = []
     @Published var actionSheetState: ActionSheetState?
     @Published var blacklistedHosts: [String] = []
-    @Published var maxItems: Int?  = Netbob.shared.maxListItems
+    @Published var maxItems: Int? = Netbob.shared.maxListItems
 
     func handleClearAction() {}
 }

--- a/Tests/NetbobTests/Core/HTTPConnectionRepositoryTests.swift
+++ b/Tests/NetbobTests/Core/HTTPConnectionRepositoryTests.swift
@@ -24,26 +24,27 @@ class HTTPConnectionRepositoryTests: XCTestCase {
     }
 
     func test_adding() {
-        var connections: [HTTPConnection]?
+        var connection: HTTPConnection?
 
-        sut.connections.sink { connections = $0 }.store(in: &subscriptions)
+        sut.latestConnection.sink { connection = $0 }.store(in: &subscriptions)
         sut.store(.fake())
 
-        XCTAssertEqual(connections, [.fake()])
+        XCTAssertEqual(connection, .fake())
     }
 
-    func test_clearing() {
+    func test_store_and_clearing() {
         // given
-        var connections: [HTTPConnection]?
-        sut.connections.sink { connections = $0 }.store(in: &subscriptions)
+        mockDiskStorage.readReturnValue = [.fake(), .fake()]
+        XCTAssertEqual(sut.current, [.fake(), .fake()])
         sut.store(.fake())
         sut.store(.fake())
-        XCTAssertEqual(connections, [.fake(), .fake()])
+        XCTAssertEqual(sut.current, [.fake(), .fake(), .fake(), .fake()])
+        XCTAssertEqual(mockDiskStorage.calls, [.read, .store, .store])
 
         // when
         sut.clear()
 
         // then
-        XCTAssertEqual(connections, [])
+        XCTAssertEqual(sut.current, [])
     }
 }

--- a/Tests/NetbobTests/Mocks/HTTPConnectionRepositoryMock.swift
+++ b/Tests/NetbobTests/Mocks/HTTPConnectionRepositoryMock.swift
@@ -15,11 +15,8 @@ class HTTPConnectionRepositoryMock: HTTPConnectionRepositoryProtocol {
 
     var current: [HTTPConnection] = []
 
-    lazy var connections: AnyPublisher<[HTTPConnection], Never> = connectionsSubject.eraseToAnyPublisher()
-    let connectionsSubject = PassthroughSubject<[HTTPConnection], Never>()
-
-    lazy var filteredConnections: AnyPublisher<[HTTPConnection], Never> = filteredConnectionsSubject.eraseToAnyPublisher()
-    let filteredConnectionsSubject = PassthroughSubject<[HTTPConnection], Never>()
+    lazy var latestConnection: AnyPublisher<HTTPConnection, Never> = connectionSubject.eraseToAnyPublisher()
+    let connectionSubject = PassthroughSubject<HTTPConnection, Never>()
 
     var allowedContentTypes = CurrentValueSubject<[HTTPContentType], Never>(HTTPContentType.allCases)
 

--- a/Tests/NetbobTests/Modules/List/ListViewStateTests.swift
+++ b/Tests/NetbobTests/Modules/List/ListViewStateTests.swift
@@ -25,7 +25,6 @@ class ListViewStateTests: XCTestCase {
         XCTAssertEqual(sut.connections.count, 0)
         mockHttpConnectionRepository.connectionSubject.send(.fake())
         XCTAssertEqual(sut.connections.count, 0)
-
     }
 
     func test_createsViewData() throws {

--- a/Tests/NetbobTests/Modules/List/ListViewTests.swift
+++ b/Tests/NetbobTests/Modules/List/ListViewTests.swift
@@ -8,9 +8,22 @@ import XCTest
 
 class ListViewTests: XCTestCase {
     func test_listView() {
+        guard let gmt = TimeZone(secondsFromGMT: 0) else {
+            XCTFail("GMT could not be initialized")
+            return
+        }
+        TimeZoneProvider.shared.current = gmt
+
         let view = ListView(state: ListViewStateMock())
 
-        assertSnapshot(matching: view, as: .image(layout: .device(config: .iPhoneSe), traits: .init(userInterfaceStyle: .light)))
+        assertSnapshot(
+            matching: view,
+            as: .image(
+                precision: 0.9995,
+                layout: .device(config: .iPhoneSe),
+                traits: .init(userInterfaceStyle: .light)
+            )
+        )
     }
 }
 


### PR DESCRIPTION
This PR changes the handling of Connections. 
They are only read from the storage once the view is shown and then cached. 
In addition, when refreshing the actual ListView, not all connections are mapped when a new connection comes in, but only the latest is mapped and added.
Also an optional maxListItems has been introduced, wich defaults to Int.max.