### PR TITLE
Add button to save logs on documents directory

### DIFF
--- a/Sources/Netbob/Core/LogFileProvider.swift
+++ b/Sources/Netbob/Core/LogFileProvider.swift
@@ -27,32 +27,20 @@ class LogFileProvider: LogFileProviderProtocol {
     }
 
     func createFullLog() throws -> URL {
-        let deviceModel = UIDevice.current.model
-        let osVersion = UIDevice.current.systemVersion
-        let appVersion = Bundle.main.appVersion
-
-        let string = "Device: \(deviceModel)\n" +
-            "OS Version: \(osVersion)\n" +
-            "App Version: \(appVersion)\n\n" +
+        let fullLog = .logHeader +
             httpConnectionRepository
-            .current
-            .map { $0.toString(includeBody: true) }
-            .joined(separator: "\n\n\n\(String(repeating: "-", count: 30))\n\n\n")
-
+                .current
+                .map { $0.toString(includeBody: true) }
+                .joined(separator: "\n\n\n\(String(repeating: "-", count: 30))\n\n\n")
         let logFileUrl = fileManager.temporaryDirectory.appendingPathComponent("session.log")
-        try writeAction(string, logFileUrl)
+        try writeAction(fullLog, logFileUrl)
         return logFileUrl
     }
 
     func createSingleLog(from connection: HTTPConnection, includeBody: Bool) throws -> URL {
-        let deviceModel = UIDevice.current.model
-        let osVersion = UIDevice.current.systemVersion
-        let appVersion = Bundle.main.appVersion
-
-        let string = "Device: \(deviceModel)\n" +
-            "OS Version: \(osVersion)\n" +
-            "App Version: \(appVersion)\n\n" +
+        let string = .logHeader +
             connection.toString(includeBody: includeBody)
+
         let logFileUrl = fileManager.temporaryDirectory.appendingPathComponent("single-connection.log")
         try writeAction(string, logFileUrl)
         return logFileUrl
@@ -158,5 +146,17 @@ private extension HTTPConnection {
         }
 
         return string
+    }
+}
+
+private extension String {
+    static var logHeader: Self {
+        let deviceModel = UIDevice.current.model
+        let osVersion = UIDevice.current.systemVersion
+        let appVersion = Bundle.main.appVersion
+
+        return "Device: \(deviceModel)\n" +
+            "OS Version: \(osVersion)\n" +
+            "App Version: \(appVersion)\n\n"
     }
 }

--- a/Sources/Netbob/Modules/List/ListView.swift
+++ b/Sources/Netbob/Modules/List/ListView.swift
@@ -32,6 +32,11 @@ struct ListView: View {
             } label: {
                 Image(systemName: "square.and.arrow.up")
             }
+            Button {
+                state.handleSaveAction()
+            } label: {
+                Image(systemName: "square.and.arrow.down")
+            }
             NavigationLink(destination: InfoView(state: InfoViewState())) {
                 Image(systemName: "info.circle")
             }

--- a/Sources/Netbob/Modules/List/ListViewState.swift
+++ b/Sources/Netbob/Modules/List/ListViewState.swift
@@ -11,6 +11,7 @@ class ListViewStateAbstract: ObservableObject {
     func onAppear() {}
     func onDisappear() {}
     func handleShareAction() {}
+    func handleSaveAction() {}
 }
 
 final class ListViewState: ListViewStateAbstract {
@@ -47,6 +48,14 @@ final class ListViewState: ListViewStateAbstract {
         do {
             let logFileUrl = try logFileProvider.createFullLog()
             activitySheetState = ActivitySheetState(items: [logFileUrl])
+        } catch {
+            Netbob.log(String(describing: error))
+        }
+    }
+
+    override func handleSaveAction() {
+        do {
+            _ = try logFileProvider.createFullLog()
         } catch {
             Netbob.log(String(describing: error))
         }

--- a/Sources/Netbob/Modules/List/ListViewState.swift
+++ b/Sources/Netbob/Modules/List/ListViewState.swift
@@ -55,7 +55,7 @@ final class ListViewState: ListViewStateAbstract {
 
     override func handleSaveAction() {
         do {
-            _ = try logFileProvider.createFullLog()
+            try logFileProvider.saveFullLog()
         } catch {
             Netbob.log(String(describing: error))
         }

--- a/Tests/NetbobTests/Core/LogFileProviderTests.swift
+++ b/Tests/NetbobTests/Core/LogFileProviderTests.swift
@@ -28,7 +28,7 @@ class LogFileProviderTests: XCTestCase {
         )
     }
 
-    func test_singleLog() throws {
+    func test_createSingleLog() throws {
         let url = try sut.createSingleLog(from: .fake(), includeBody: true)
 
         XCTAssertEqual(mockFileManager.calls, [])
@@ -37,12 +37,22 @@ class LogFileProviderTests: XCTestCase {
         XCTAssertEqual(writeActionURLs, ["tmp/single-connection.log"])
     }
 
-    func test_fullLog() throws {
+    func test_createFullLog() throws {
         let url = try sut.createFullLog()
 
         XCTAssertEqual(mockFileManager.calls, [])
         XCTAssertEqual(mockConnectionRepository.calls, [])
         XCTAssertEqual(url.absoluteString, "tmp/session.log")
         XCTAssertEqual(writeActionURLs, ["tmp/session.log"])
+    }
+
+    func test_saveFullLog() throws {
+        mockFileManager.urlsReturnValue = [URL(string: "Documents")!]
+
+        try sut.saveFullLog()
+
+        XCTAssertEqual(mockFileManager.calls, [.urls])
+        XCTAssertEqual(mockConnectionRepository.calls, [])
+        XCTAssertEqual(writeActionURLs, ["Documents/network-logs.txt"])
     }
 }

--- a/Tests/NetbobTests/Core/LogFileProviderTests.swift
+++ b/Tests/NetbobTests/Core/LogFileProviderTests.swift
@@ -11,6 +11,8 @@ class LogFileProviderTests: XCTestCase {
 
     var sut: LogFileProvider!
 
+    var writeActionURLs: [String] = []
+
     override func setUp() {
         super.setUp()
 
@@ -20,7 +22,9 @@ class LogFileProviderTests: XCTestCase {
         sut = LogFileProvider(
             fileManager: mockFileManager,
             httpConnectionRepository: mockConnectionRepository,
-            writeAction: { _, _ in }
+            writeAction: { _, url in
+                self.writeActionURLs.append(url.absoluteString)
+            }
         )
     }
 
@@ -30,6 +34,7 @@ class LogFileProviderTests: XCTestCase {
         XCTAssertEqual(mockFileManager.calls, [])
         XCTAssertEqual(mockConnectionRepository.calls, [])
         XCTAssertEqual(url.absoluteString, "tmp/single-connection.log")
+        XCTAssertEqual(writeActionURLs, ["tmp/single-connection.log"])
     }
 
     func test_fullLog() throws {
@@ -38,5 +43,6 @@ class LogFileProviderTests: XCTestCase {
         XCTAssertEqual(mockFileManager.calls, [])
         XCTAssertEqual(mockConnectionRepository.calls, [])
         XCTAssertEqual(url.absoluteString, "tmp/session.log")
+        XCTAssertEqual(writeActionURLs, ["tmp/session.log"])
     }
 }

--- a/Tests/NetbobTests/Mocks/LogFileProviderMock.swift
+++ b/Tests/NetbobTests/Mocks/LogFileProviderMock.swift
@@ -8,6 +8,7 @@ import Foundation
 class LogFileProviderMock: LogFileProviderProtocol {
     enum Calls: Equatable {
         case createFullLog
+        case saveFullLog
         case createSingleLog(connection: HTTPConnection, includeBody: Bool)
     }
 
@@ -17,6 +18,10 @@ class LogFileProviderMock: LogFileProviderProtocol {
     func createFullLog() throws -> URL {
         calls.append(.createFullLog)
         return createFullLogReturnValue
+    }
+
+    func saveFullLog() throws {
+        calls.append(.saveFullLog)
     }
 
     var createSingleLogReturnValue = URL(string: "http://fake.fake")!

--- a/Tests/NetbobTests/Mocks/LogFileProviderMock.swift
+++ b/Tests/NetbobTests/Mocks/LogFileProviderMock.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright © Marc Schultz. All rights reserved.
+//
+
+import Foundation
+@testable import Netbob
+
+class LogFileProviderMock: LogFileProviderProtocol {
+    enum Calls: Equatable {
+        case createFullLog
+        case createSingleLog(connection: HTTPConnection, includeBody: Bool)
+    }
+
+    var calls: [Calls] = []
+
+    var createFullLogReturnValue = URL(string: "http://fake.fake")!
+    func createFullLog() throws -> URL {
+        calls.append(.createFullLog)
+        return createFullLogReturnValue
+    }
+
+    var createSingleLogReturnValue = URL(string: "http://fake.fake")!
+    func createSingleLog(from connection: HTTPConnection, includeBody: Bool) throws -> URL {
+        calls.append(.createSingleLog(connection: connection, includeBody: includeBody))
+        return createSingleLogReturnValue
+    }
+}

--- a/Tests/NetbobTests/Modules/List/ListViewStateTests.swift
+++ b/Tests/NetbobTests/Modules/List/ListViewStateTests.swift
@@ -7,6 +7,7 @@ import XCTest
 
 class ListViewStateTests: XCTestCase {
     let mockHttpConnectionRepository = HTTPConnectionRepositoryMock()
+    let mockLogFileProvider = LogFileProviderMock()
 
     var sut: ListViewState!
 
@@ -15,6 +16,7 @@ class ListViewStateTests: XCTestCase {
 
         sut = ListViewState(
             httpConnectionRepository: mockHttpConnectionRepository,
+            logFileProvider: mockLogFileProvider,
             scheduler: .test
         )
     }
@@ -23,6 +25,7 @@ class ListViewStateTests: XCTestCase {
         XCTAssertEqual(sut.connections.count, 0)
         mockHttpConnectionRepository.connectionSubject.send(.fake())
         XCTAssertEqual(sut.connections.count, 0)
+        XCTAssertEqual(mockLogFileProvider.calls, [])
     }
 
     func test_createsViewData() throws {
@@ -48,6 +51,7 @@ class ListViewStateTests: XCTestCase {
         XCTAssertEqual(firstConnection.requestQuery, "?a=1,b=2,c=3")
         XCTAssertEqual(firstConnection.responseStatusCode, "200")
         XCTAssertEqual(firstConnection.status, .success)
+        XCTAssertEqual(mockLogFileProvider.calls, [])
     }
 
     func test_no_subscription_after_onDisappear() {
@@ -62,5 +66,17 @@ class ListViewStateTests: XCTestCase {
         mockHttpConnectionRepository.connectionSubject.send(.fake())
 
         XCTAssertEqual(sut.connections.count, 0)
+    }
+
+    func test_handleSaveAction() {
+        sut.handleSaveAction()
+
+        XCTAssertEqual(mockLogFileProvider.calls, [.createFullLog])
+    }
+
+    func test_createFullLog() {
+        sut.handleShareAction()
+
+        XCTAssertEqual(mockLogFileProvider.calls, [.createFullLog])
     }
 }

--- a/Tests/NetbobTests/Modules/List/ListViewStateTests.swift
+++ b/Tests/NetbobTests/Modules/List/ListViewStateTests.swift
@@ -71,7 +71,7 @@ class ListViewStateTests: XCTestCase {
     func test_handleSaveAction() {
         sut.handleSaveAction()
 
-        XCTAssertEqual(mockLogFileProvider.calls, [.createFullLog])
+        XCTAssertEqual(mockLogFileProvider.calls, [.saveFullLog])
     }
 
     func test_createFullLog() {


### PR DESCRIPTION
* ~Bumped minimum swift-snapshot-testing to 1.17.4 because it was already resolving to that version but compilation was breaking~ Removed after rebase
* Added a button to save the current logs to the document directory: `Documents/network-logs.txt`

<img src="https://github.com/user-attachments/assets/c1952d29-ef11-4b10-82d7-755a085cbf85" width="450px" />