### PR TITLE
Stop ignoring Package.resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,15 @@ xcuserdata/
 *.xcscmblueprint
 
 # Swift Package Manager
-.package.resolved
-Package.resolved
+.swiftpm/*
+!.swiftpm/xcode/
+.swiftpm/xcode/*
+!.swiftpm/xcode/xcshareddata/
+.swiftpm/xcode/xcshareddata/*
+!.swiftpm/xcode/xcshareddata/xcschemes/
+.swiftpm/xcode/xcshareddata/xcschemes/*
+!.swiftpm/xcode/xcshareddata/xcschemes/*.xcscheme
 
 # Tuist
+.package.resolved
 **/Derived

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-snapshot-testing",
+        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
+        "state": {
+          "branch": null,
+          "revision": "6d932a79e7173b275b96c600c86c603cf84f153c",
+          "version": "1.17.4"
+        }
+      },
+      {
+        "package": "swift-syntax",
+        "repositoryURL": "https://github.com/swiftlang/swift-syntax",
+        "state": {
+          "branch": null,
+          "revision": "515f79b522918f83483068d99c68daeb5116342d",
+          "version": "600.0.0-prerelease-2024-08-20"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
Checking in the Package.resolved into Git will help Dependabot to update dependencies correctly. Otherwise Dependabot would always compare the newest versions with the newest versions, not detecting outdated ones.